### PR TITLE
Several changes to help stabilize things before sharing.

### DIFF
--- a/.skiff/kube.yaml
+++ b/.skiff/kube.yaml
@@ -29,7 +29,14 @@ metadata:
   name: lm-explorer
   namespace: lm-explorer
 spec:
-  replicas: 1
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      # Let is spin up a full set of replicas since they take so long to
+      # initialize
+      maxSurge: 3
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -40,22 +47,30 @@ spec:
       containers:
         - name: lm-explorer
           image: '%IMAGE%'
+          # Checks whether a newly started pod is ready to receive traffic.
+          # We wait as long as 5 minutes, as the lm-explorer loads a pretty big
+          # model form S3. Logs show this takes ~3 minutes or so in GCP land
+          # so we'll call 5 minutes good.
           readinessProbe:
-            failureThreshold: 3
+            failureThreshold: 9
+            periodSeconds: 30
             httpGet:
               path: /
               port: 8000
               scheme: HTTP
-            initialDelaySeconds: 1
+            initialDelaySeconds: 30
+          # Checks whehter a pod is still alive and can continue to receive traffic.
+          # After 6 failed checks spaced by 10 seconds, the pod will be killed and restarted.
+          # See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes
           livenessProbe:
+            failureThreshold: 6
+            periodSeconds: 10
             httpGet:
               path: /
               port: 8000
               scheme: HTTP
             initialDelaySeconds: 1
           resources:
-            limits:
-              cpu: "2"
             requests:
               cpu: "1"
               memory: 1000Mi

--- a/.skiff/kube.yaml
+++ b/.skiff/kube.yaml
@@ -32,7 +32,7 @@ spec:
   replicas: 3
   strategy:
     rollingUpdate:
-      # Let is spin up a full set of replicas since they take so long to
+      # Let k8s spin up a full set of replicas since they take so long to
       # initialize
       maxSurge: 3
       maxUnavailable: 1

--- a/app.py
+++ b/app.py
@@ -198,7 +198,7 @@ def main(args):
     app = make_app()
     CORS(app)
 
-    http_server = WSGIServer(('0.0.0.0', args.port), app)
+    http_server = WSGIServer(('0.0.0.0', args.port), app, log=sys.stdout)
     print(f"Model loaded, serving demo on port {args.port}")
     http_server.serve_forever()
 


### PR DESCRIPTION
* Allow 5 minutes for pods to be ready, since the model
  can take a long time to download.
* Set log messages to go to stdout instead of stderr so
  that we can more easily look for errors / issues
  in past logs (right now they're all printed to
  stderr, as that's the default in gevent).
* Run 3 versions so we've got hosts to fallback on in
  the event of an error.
* Allow a full suite of replicas to be created when deploying
  so they can all simultaneously download the model (this
  should make deployments a tad faster).