### PR TITLE
Add google analytics.

### DIFF
--- a/.skiff/kube.yaml
+++ b/.skiff/kube.yaml
@@ -74,6 +74,9 @@ spec:
             requests:
               cpu: "1"
               memory: 1000Mi
+          env:
+            - name: GOOGLE_ANALYTICS_UA
+              value: UA-120916510-4
 ---
 apiVersion: v1
 kind: Service

--- a/templates/app.html
+++ b/templates/app.html
@@ -13,6 +13,15 @@
     </style>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt"
         crossorigin="anonymous">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics_ua }}"></script>
+    <script>
+        // Disable analytics unless we're in the live environment.
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{ google_analytics_ua }}');
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
This adds google analytics, and parameterizes the UA
so that we don't pollute production with metrics
logged in other environments.

The default UA is that for staging / development / any
non live environment.

I also added a flag, `--dev`, so that the server can
be ran locally in a mode where it reloads the template
with each request (to allow for more rapid local
development).